### PR TITLE
✨ feat(provenance): use placeholder for dropdown insertion

### DIFF
--- a/provenance/ltd-sphinx.js.in
+++ b/provenance/ltd-sphinx.js.in
@@ -71,7 +71,7 @@ function createProvenanceDropdown() {
   tempDiv.innerHTML = flyoutHTML.trim();
   const dropdownBox = tempDiv.firstChild;
 
-  const mainContent = document.querySelector('div[role="main"]');
+  const mainContent = document.querySelector('@INSERT_POINT@');
   if (mainContent) {
     mainContent.prepend(dropdownBox);
   } else {


### PR DESCRIPTION
Replaced hardcoded insertion point with `@INSERT_POINT@` placeholder, which allowed flexible insertion in different contexts.