### PR TITLE
🎨 style(flyout): remove content from dd::before element

### DIFF
--- a/flyout/ltd-flyout.js
+++ b/flyout/ltd-flyout.js
@@ -283,6 +283,10 @@ function addStyles() {
       padding: 0 !important;
     }
 
+    .ltd-flyout-content dd::before {
+      content: none !important;
+    }
+
     .ltd-flyout-content dd.newline {
       flex-basis: 100% !important;
       height: 0 !important;


### PR DESCRIPTION
Eliminate the content from the `dd::before` pseudo-element in the `ltd-flyout-content` class to suppress the unexpected numbering in the Project Links section.

Close: #6 