### PR TITLE
✨ feat(provenance): add upstream owner variable

### DIFF
--- a/provenance/ltd-sphinx.js.in
+++ b/provenance/ltd-sphinx.js.in
@@ -6,11 +6,15 @@
  */
 function createProvenanceDropdown() {
   // 1. Define the HTML and CSS as template literals.
+  const upstreamOwner = "@UPSTREAM_OWNER@" !== "" ? "@UPSTREAM_OWNER@" : "the upstream owner";
+  const upstreamDocs  = "@UPSTREAM_DOCS@";
+  const upstreamRepo  = "@UPSTREAM_REPO@";
+
   const flyoutHTML = `
     <details class="provenance-dropdown">
       <summary class="provenance-summary"><strong>Provenance</strong></summary>
       <div class="provenance-content">
-        The translation is <strong>unofficial</strong> and <strong>community-driven</strong>. If you find any inaccuracies, always refer to the <a href="@UPSTREAM_DOCS@">official documentation</a> or the <a href="@UPSTREAM_REPO@">source repository</a> of the upstream project for the most reliable information.
+        The translation is <strong>unofficial</strong> and <strong>community-driven</strong>. <strong>No endorsement</strong> by ${upstreamOwner} is intended. If you find any inaccuracies, always refer to the <a href="${upstreamDocs}">official documentation</a> or the <a href="${upstreamRepo}">source repository</a> of the upstream project for the most reliable information.
       </div>
     </details>
   `;


### PR DESCRIPTION
Add upstream owner variable with conditional fallback and convert template placeholders to JavaScript template literals for better dynamic content handling. Include "No endorsement" disclaimer in the provenance dropdown content.

- Add `@UPSTREAM_OWNER@` template placeholder for upstream owner.
- Add upstreamOwner variable with fallback to "the upstream owner".
- Convert `@UPSTREAM_DOCS@` to JavaScript variable, upstreamDocs.
- Convert `@UPSTREAM_REPO@` to JavaScript variable, upstreamRepo.
- Add "No endorsement" statement with dynamic upstreamOwner.